### PR TITLE
Docs from sdk txt

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -39,11 +39,17 @@ jobs:
             exit 1
           fi
 
+          # Do not mirror IQM Benchmarks and Cirq IQM
+          sed -i '/^iqm-benchmarks/d; /^cirq-iqm/d; /^#/d' sdk.txt
+
           # Download all source distributions
           if ! pip download --no-deps --no-binary=:all: -r sdk.txt -d ./temp; then
             echo "Error: Failed to download some packages."
             exit 1
           fi
+
+          # Restore sdk.txt
+          git checkout sdk.txt
 
           # Flag to track if any changes were made
           CHANGES=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,75 +6,33 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'sdk.txt'
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
     # Allow manual triggering
 
-env:
-  PACKAGES: "iqm-pulse iqm-exa-common iqm-station-control-client iqm-pulla[qiskit,qir] iqm-benchmarks cirq-iqm iqm-client iqm-data-definitions"
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: python:3.11
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-      - name: Install dependencies
-        working-directory: ./docs
-        run: |
-          pip install --upgrade pip
-          pip install -r requirements.txt
-          apt-get update
-          apt-get install -y graphviz
-
-      - name: Build sphinx documentation
-        working-directory: ./docs
-        run: |
-          mkdir -p public
-          mkdir -p temp
-          cd temp
-
-          for package in $PACKAGES; do
-            echo "Processing $package..."
-            # download source distribution
-            python -m pip download --no-deps --no-binary :all: $package
-            echo "installing package (required for namespace resolution when building docs with Sphinx)..."
-            python -m pip install $package
-            echo "unarchiving source distribution and cd-ing into the resulting directory..."
-            tar -xvzf *.tar.gz
-            cd "$(tar -tzf *.tar.gz | head -1 | cut -f1 -d"/")"
-            echo "building docs..."
-            USE_LOCAL_TARGET=true python -m sphinx docs ../../public/${package%[*}
-            # add .nojekyll in order to stop Github from treating the directory as a Jekyll blog generator,
-            # which ignores directories starting with underscore
-            touch ../../public/${package%[*}/.nojekyll
-            echo "cleaning up..."
-            cd ..
-            rm -rf *
-          done
-
-          cd ..
-          rm -rf temp
-          rm -rf public/jupyter_execute
-          touch public/.nojekyll
-
-      - name: Generate search index
-        working-directory: ./docs
-        run: python generate_search_index.py
-
-      - name: Ensure search index is in public folder
-        working-directory: ./docs
-        run: |
-          cp search.json public/ || echo "No search index found"
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.11'
 
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          working-directory: ./docs
           node-version: 18
+
+      - name: Build documentation
+        run: |
+          bash build.sh
 
       - name: Install and build React project
         working-directory: ./docs
@@ -88,11 +46,6 @@ jobs:
           mkdir -p public
           cp -r dist/* public/
           cp src/favicon.ico public/favicon.ico
-
-      - name: Install rsync
-        working-directory: ./docs
-        run: |
-          apt-get update && apt-get install -y rsync
 
       - name: Publish to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 dist
 .DS_Store
 .vite
+docs/public
+docs/temp
+docs/search.json

--- a/README.md
+++ b/README.md
@@ -1,24 +1,9 @@
 # IQM SDK & Docs
 
-This repository holds the mirror of the source code of IQM SDK — a collection of libraries for operating IQM's quantum computers.
+This repository holds the mirror of the source code of IQM SDK: a collection of libraries for operating IQM's quantum computers.
 It also builds and publishes documentation pages for those libraries: [https://docs.meetiqm.com/](https://docs.meetiqm.com/).
 The versions in this mirror correspond to the latest stable release of IQM QCCSW (Quantum Computing Control Software).
 
 This GitHub repository is a read-only mirror that isn't used for accepting contributions.
 
-# Building the documentation locally
-It uses a Python script in `generate_search_index.py` to generate a search index for the documentation. To build the documentation locally, you need to have Python installed and then run the script based on the folders, or retrieve a `search.json` document from the GitHub repository and the [GitHub Pages branch](https://github.com/iqm-finland/docs/tree/gh-pages).
-
-In order to locally run the React application, you need to have Node.js installed. Then you can run the following commands:
-
-```bash
-npm install
-npm run dev
-```
-
-or use Yarn:
-```bash
-yarn install
-yarn  dev
-```
-
+**For support, contact `support@meetiqm.com`**.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+cd docs
+
+# Put package names into environment variable; later used for creating directories and for the React app
+PACKAGES=$(awk '{print $1}' ../sdk.txt | tr '\n' ' ' | sed 's/ $//')
+
+echo "Building documentation for packages: $PACKAGES"
+
+# Public directory for the final site build
+mkdir -p public
+# Temporary directory for downloading and extracting the packages
+mkdir -p temp
+
+# Install the requirements for building the docs
+uv pip install pip packaging wheel
+uv pip install -r requirements.txt
+
+# Download and extract the packages' source distributions
+uv run -m pip download --no-deps --no-binary=:all: -r ../sdk.txt -d ./temp
+
+# Install the packages into the virtual environment; needed for Sphinx to resolve namespaces
+uv pip install -r ../sdk.txt
+
+echo "Downloaded packages:"
+ls -la temp
+
+# Iterate over the downloaded source distributions
+for SDIST_FILE in ./temp/*.tar.gz; do
+    # Extract the package sdist to temp directory
+    echo "Extracting $SDIST_FILE..."
+    tar -xzf "$SDIST_FILE" -C ./temp
+
+    SRC_DIR="${SDIST_FILE%.tar.gz}"
+    echo "Extracted to ${SRC_DIR}"
+
+    # Go to the package source directory
+    cd "$SRC_DIR"
+    # Get the package name from the pyproject.toml file
+    PKG_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'])")
+
+    # Build the docs and save to the public directory
+    # we are now in ROOT/temp/<package_name>/ and public dir is ROOT/public/
+    USE_LOCAL_TARGET=true python -m sphinx docs ../../public/${PKG_NAME%[*}
+    # add .nojekyll in order to stop Github from treating the directory as a Jekyll blog generator,
+    # which ignores directories starting with underscore
+    touch ../../public/${PKG_NAME%[*}/.nojekyll
+
+    # Go back to the docs directory
+    cd ../..
+done
+
+# Remove the Jupyter notebook execution directory
+rm -rf public/jupyter_execute
+# add .nojekyll in order to stop Github from treating the directory as a Jekyll blog generator,
+# which ignores directories starting with underscore
+touch public/.nojekyll
+
+uv run generate_search_index.py
+cp search.json public/ || echo "No search index found"

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,0 +1,59 @@
+# Building the documentation locally
+
+## Prerequisites
+
+- [`uv`](https://github.com/astral-sh/uv)
+- Node.js
+
+## Info
+
+`build.sh` is a script that is used by Github actions to build the documentation for each package, and compile a common search index.
+Namely, it performs the following actions:
+
+- download source distributions of packages specified in `../sdk.txt`
+- install the packages specified in `../sdk.txt` into the current environment
+- for each source distribution:
+    - extract the archive
+    - determine the package name by parsing its `pyproject.toml`
+    - build documentation by calling `sphinx` and saves it into `public/<PACKAGE_NAME>`
+- call `python generate_search_index.py` to generate the search index file `search.json`
+
+Once packages' documentation directories and the search index file are in place, the front page (single-page app) can be built.
+
+## Instructions
+
+Create a Python environment with `uv`:
+
+```bash
+uv venv --python 3.11
+source .venv/bin/activate
+```
+
+Build the documentation for each package, and compile a common search index:
+
+```bash
+chmod +x build.sh
+./build.sh
+```
+
+Build the front page for production use:
+
+```bash
+npm ci
+npm run build
+cp -r dist/* public/
+cp src/favicon.ico public/favicon.ico
+```
+
+Then you can `cd` into `public` and serve the site with any web server, e.g. `python3 -m http.server 8000`, then open http://localhost:8000..
+
+Alternatively, build the site locally in development mode:
+
+```bash
+npm install
+npm run dev
+```
+
+(if you use Yarn: `yarn install && yarn dev`)
+
+If you only need to work on the main React-powered page, no need to run `build.sh`; instead, just download `search.json` file from the [GitHub Pages branch](https://github.com/iqm-finland/docs/tree/gh-pages), put it in `./docs` and run `npm install && npm run dev`.

--- a/sdk.txt
+++ b/sdk.txt
@@ -1,6 +1,8 @@
-iqm-data-definitions >=2.8, <3.0
+iqm-data-definitions >=2.10, <3.0
 iqm-exa-common >=26.2, <27.0
 iqm-station-control-client >=3.3, <4.0
 iqm-pulse >=8.1, <9.0
 iqm-pulla[qiskit,qir] >=6.2, <7.0
 iqm-client >=22.3, <23.0
+iqm-benchmarks >=2.29, <3.0
+cirq-iqm >=16.1, <17.0


### PR DESCRIPTION
- Build docs and mirrors from the same `sdk.txt`.
- Introduce `build.sh` script instead of long workflow.
- Add IQM Benchmarks and Cirq-on-IQM to `sdk.txt`.
- Blacklist IQM Benchmarks and Cirq-on-IQM from mirroring.