### PR TITLE
Bump SDK 4.4 versions

### DIFF
--- a/sdk4_4.txt
+++ b/sdk4_4.txt
@@ -1,9 +1,9 @@
 iqm-data-definitions==2.19
-iqm-exa-common==27.4.0
-iqm-station-control-client==12.0.0
-iqm-pulse==12.7.0
-iqm-client[qiskit,cirq,cli]==33.0.0
-iqm-pulla[qiskit,qir]==12.0.0
+iqm-exa-common==27.4.1
+iqm-station-control-client==12.0.1
+iqm-pulse==12.7.1
+iqm-client[qiskit,cirq,cli]==33.0.1
+iqm-pulla[qiskit,qir]==12.0.1
 iqm-qaoa==1.38.1
 qrisp== 0.7.13
 iqm-benchmarks==2.52


### PR DESCRIPTION
4.4.1 patch versions contain a bugfix about missing version ranges in package dependencies