### PR TITLE
Force single commit on gh-pages branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,5 +104,7 @@ jobs:
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         with:
           folder: docs/public
+          force: true
+          single-commit: true
           git-config-name: 'IQM'
           git-config-email: 'support@meetiqm.com'


### PR DESCRIPTION
If this PR is merged, after the next deploy runs gh-pages will be a single commit. The same binary/large docbuild generated files will still be committed just like before, but without history. The repo size will shrink substantially.

gh-pages branch has a lot of bloat: 550 commits, ~1M objects reachable only from it. Built Sphinx documentation has been committed repeatedly, and git can't delta-compress these binary/large generated files very well. gh-pages history has ~99 GiB of uncompressed blobs which git compresses down to ~1.92 GiB.

Some copilot-generated git command snippets to find out the culprit to the large repo size:

```sh
# Overall repo size
$ git count-objects -vH
count: 9
size: 36.00 KiB
in-pack: 1043843
packs: 1
size-pack: 1.92 GiB
prune-packable: 0
garbage: 0
size-garbage: 0 bytes
```
```sh
# How many commits on gh-pages vs main
$ git rev-list --count origin/gh-pages
550
$ git rev-list --count origin/main
191
```

```sh
# Objects reachable ONLY from gh-pages (not main)
$ git rev-list --objects origin/gh-pages --not origin/main | wc -l
 1038710
```
```sh
# Top 20 largest file paths across all gh-pages history (cumulative size per path)
$ git rev-list --objects origin/gh-pages | \
  git cat-file --batch-check='%(objecttype) %(objectsize) %(rest)' | \
  sed -n 's/^blob //p' | \
  awk '{sizes[$2]+=$1} END {for (f in sizes) print sizes[f], f}' | \
  sort -rnk1 | head -20
19541046779 iqm-pulla/Example
11959638318 iqm-pulla/.doctrees/environment.pickle
7328731286 sdk4_1/iqm-pulla/Example
5709848118 sdk4_3/iqm-pulla/Example
5637333302 sdk3_4/iqm-pulla/Example
4605573872 sdk4_0/iqm-pulla/Example
2699236901 iqm-pulla/.doctrees/Example
2335628647 iqm-pulse/.doctrees/environment.pickle
1617097209 iqm-exa-common/.doctrees/environment.pickle
1435234192 sdk4_4/iqm-pulla/Example
956960808 iqm-client/.doctrees/environment.pickle
926135623 cirq-iqm/.doctrees/environment.pickle
852869997 iqm-benchmarks/.doctrees/environment.pickle
792993945 qiskit-iqm/.doctrees/environment.pickle
773931414 iqm-station-control-client/.doctrees/environment.pickle
675754748 search.json
439803762 iqm-pulla/Quick
336686506 iqm-pulla/Custom
226014533 sdk4_1/search_sdk4_1.json
222072051 sdk4_3/search_sdk4_3.json
```
```sh
# Size by category across gh-pages history
$ git rev-list --objects origin/gh-pages | \
  git cat-file --batch-check='%(objecttype) %(objectsize) %(rest)' | \
  sed -n 's/^blob //p' | \
  awk '
    /\.doctrees/    {doctrees+=$1}
    /search.*\.json|searchindex/ {search+=$1}
    /\.html$/       {html+=$1}
    /^assets\/index-/ {assets+=$1}
    {total+=$1}
    END {
      g=1073741824
      printf ".doctrees:      %.2f GiB\n", doctrees/g
      printf "HTML files:     %.2f GiB\n", html/g
      printf "Search indexes: %.2f GiB\n", search/g
      printf "Vite assets:    %.2f GiB\n", assets/g
      printf "Total blobs:    %.2f GiB\n", total/g
    }'
.doctrees:      22,05 GiB
HTML files:     73,60 GiB
Search indexes: 2,35 GiB
Vite assets:    0,00 GiB
Total blobs:    99,11 GiB
```